### PR TITLE
Improve compatibility with other frameworks and future OMF.

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -4,4 +4,6 @@ set -gx USE_CCACHE 1
 
 set -q CCACHE_ROOT; or set -l CCACHE_ROOT /usr/lib/ccache/bin
 
-set PATH $CCACHE_ROOT $PATH
+if not contains "$CCACHE_ROOT" $PATH
+  set PATH $CCACHE_ROOT $PATH
+end

--- a/init.fish
+++ b/init.fish
@@ -2,8 +2,6 @@
 # See: https://source.android.com/source/initializing.html#setting-up-ccache
 set -gx USE_CCACHE 1
 
-if test -n "$CCACHE_ROOT"
-  _prepend_path $CCACHE_ROOT
-else
-  _prepend_path /usr/lib/ccache/bin
-end
+set -q CCACHE_ROOT; or set -l CCACHE_ROOT /usr/lib/ccache/bin
+
+set PATH $CCACHE_ROOT $PATH


### PR DESCRIPTION
- Use `init.fish` instead of `*.load` to require files on load, use fishier idioms.
- Only add missing paths during init.
